### PR TITLE
[Fix #16] Cache cabal configurations

### DIFF
--- a/Cask
+++ b/Cask
@@ -6,4 +6,5 @@
 (files "*el" "*.hs")
 
 (development
- (depends-on "ert-runner"))
+ (depends-on "ert-runner")
+ (depends-on "cl-lib"))


### PR DESCRIPTION
My own take at #16 and #17.  Uses a hash table, and caches all configurations of all projects.
