### PR TITLE
Use extracted options and dependencies.

### DIFF
--- a/flycheck-haskell.el
+++ b/flycheck-haskell.el
@@ -181,7 +181,12 @@ string, or nil, if no sandbox configuration file was found."
                         flycheck-ghc-search-path))
     (setq-local flycheck-ghc-language-extensions
                 (append .extensions .languages
-                        flycheck-ghc-language-extensions))))
+                        flycheck-ghc-language-extensions))
+    (setq-local flycheck-ghc-args
+                (append '("-hide-all-packages")
+                        (apply #'append (mapcar (lambda (p) (list "-package" p)) .dependencies))
+                        .other-options
+                        flycheck-ghc-args))))
 
 (defun flycheck-haskell-configure ()
   "Set paths and package database for the current project."


### PR DESCRIPTION
Use options and dependencies from .cabal files to build up proper
flycheck-ghc-args value.