### PR TITLE
Handle .cabal conditionals

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,5 +23,4 @@ install:
   - cask install
 script:
   - make EMACS=$EMACS compile
-  - make HLINTFLAGS=-c lint
   - make EMACS=$EMACS test

--- a/Cask
+++ b/Cask
@@ -8,4 +8,4 @@
  "get-cabal-configuration.hs")
 
 (development
- (depends-on "cl-lib"))
+ (depends-on "cl-lib" "dash"))

--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,6 @@ EMACS = emacs
 EMACSFLAGS =
 GHC = ghc
 GHCFLAGS = -Wall -Werror -O1
-HLINT = hlint
-HLINTFLAGS =
 CASK = cask
 PKGDIR := $(shell EMACS=$(EMACS) $(CASK) package-directory)
 
@@ -18,7 +16,7 @@ PACKAGE = flycheck-haskell-$(VERSION).tar
 EMACSBATCH = $(EMACS) -Q --batch $(EMACSFLAGS)
 
 .PHONY: compile dist \
-	lint test \
+	test \
 	clean clean-elc clean-dist clean-deps \
 	deps
 
@@ -29,9 +27,6 @@ dist :
 	$(CASK) package
 
 # Test targets
-lint :
-	$(HLINT) $(HLINTFLAGS) $(HS_SRCS)
-
 test : $(EL_OBJS)
 	$(CASK) exec $(EMACSBATCH) -l flycheck-haskell.elc \
 		-l test/flycheck-haskell-test.el -f ert-run-tests-batch-and-exit

--- a/Makefile
+++ b/Makefile
@@ -10,11 +10,9 @@ PKGDIR := $(shell EMACS=$(EMACS) $(CASK) package-directory)
 # Export the used EMACS to recipe environments
 export EMACS
 
-HS_BUILDDIR = build/hs
 EL_SRCS = flycheck-haskell.el
 EL_OBJS = $(EL_SRCS:.el=.elc)
 HS_SRCS = get-cabal-configuration.hs
-HS_OBJS = $(HS_SRCS:.hs=)
 PACKAGE = flycheck-haskell-$(VERSION).tar
 
 EMACSBATCH = $(EMACS) -Q --batch $(EMACSFLAGS)
@@ -25,7 +23,7 @@ EMACSBATCH = $(EMACS) -Q --batch $(EMACSFLAGS)
 	deps
 
 # Build targets
-compile : $(EL_OBJS) $(HS_OBJS)
+compile : $(EL_OBJS)
 
 dist :
 	$(CASK) package
@@ -47,9 +45,6 @@ clean : clean-elc clean-hs clean-dist clean-deps
 clean-elc :
 	rm -rf $(EL_OBJS)
 
-clean-hs:
-	rm -rf $(HS_OBJS) $(HS_BUILDDIR)
-
 clean-dist :
 	rm -rf $(DISTDIR)
 
@@ -59,9 +54,6 @@ clean-deps :
 # File targets
 %.elc : %.el $(PKGDIR)
 	$(CASK) exec $(EMACSBATCH) -f batch-byte-compile $<
-
-%: %.hs
-	$(GHC) $(GHCFLAGS) -outputdir $(HS_BUILDDIR) -o $@ $<
 
 $(PKGDIR) : Cask
 	$(CASK) install

--- a/flycheck-haskell.el
+++ b/flycheck-haskell.el
@@ -125,7 +125,7 @@ entry, or if the cache entry is outdated."
 
 (defun flycheck-haskell-read-cabal-configuration (cabal-file)
   "Read the Cabal configuration from CABAL-FILE."
-  (let ((args (flycheck-haskell-get-configuration-args cabal-file)))
+  (let ((args (-map (lambda (d) (concat "-D" d)) (flycheck-haskell-get-cpp-defines cabal-file))))
     (setq args (append args (list flycheck-haskell-helper cabal-file)))
     (with-temp-buffer
       (let ((result (apply 'call-process flycheck-haskell-runhaskell nil t nil args)))
@@ -133,13 +133,13 @@ entry, or if the cache entry is outdated."
           (goto-char (point-min))
           (read (current-buffer)))))))
 
-(defun flycheck-haskell-get-configuration-args (cabal-file)
-  "Analyze cabal version output to determine flags for CABAL-FILE.
+(defun flycheck-haskell-get-cpp-defines (cabal-file)
+  "Analyze cabal version output to determine CPP defines for CABAL-FILE.
 
 Different versions of the Cabal library have different enough
 interfaces we have to use some CPP in our configuration helper.
 This code looks at the cabal library version to figure out what
-flags to use."
+defines to use."
   (with-temp-buffer
     (let ((result (call-process flycheck-haskell-cabal nil t nil "--version" cabal-file)))
       (when (= result 0)
@@ -149,7 +149,7 @@ flags to use."
                      (version (read value)))
           (cond
            ((< version 1.22)
-            (list "-DuseCompilerId"))))))))
+            (list "useCompilerId"))))))))
 
 (defun flycheck-haskell-read-and-cache-configuration (cabal-file)
   "Read and cache configuration from CABAL-FILE.

--- a/flycheck-haskell.el
+++ b/flycheck-haskell.el
@@ -148,8 +148,8 @@ flags to use."
                      (value (match-string-no-properties 1))
                      (version (read value)))
           (cond
-           ((>= version 1.22)
-            (list "-DuseCompilerInfo"))))))))
+           ((< version 1.22)
+            (list "-DuseCompilerId"))))))))
 
 (defun flycheck-haskell-read-and-cache-configuration (cabal-file)
   "Read and cache configuration from CABAL-FILE.

--- a/get-cabal-configuration.hs
+++ b/get-cabal-configuration.hs
@@ -23,13 +23,10 @@
 import Control.Arrow (second)
 import Data.List (nub, isPrefixOf)
 import Data.Maybe (listToMaybe)
-#ifdef useCompilerInfo
-import Distribution.Compiler (AbiTag(NoAbiTag),CompilerFlavor(GHC),CompilerId(CompilerId),CompilerInfo,buildCompilerFlavor,unknownCompilerInfo)
-import Distribution.Simple.Compiler                  (compilerInfo)
-import Distribution.Simple.Configure                 (configCompilerAuxEx)
-import Distribution.Simple.Setup                     (emptyConfigFlags)
-#else
+#ifdef useCompilerId
 import Distribution.Compiler (CompilerFlavor(GHC),CompilerId(CompilerId),buildCompilerFlavor)
+#else
+import Distribution.Compiler (AbiTag(NoAbiTag),CompilerFlavor(GHC),CompilerId(CompilerId),CompilerInfo,buildCompilerFlavor,unknownCompilerInfo)
 #endif
 import Distribution.Package (PackageName(..),PackageIdentifier(..),Dependency(..))
 import Distribution.PackageDescription (PackageDescription(..),allBuildInfo
@@ -140,14 +137,19 @@ dumpCabalConfiguration cabalFile = do
                           (condBenchmarks genericDesc)
       genericDesc' = genericDesc { condTestSuites = flaggedTests
                                  , condBenchmarks = flaggedBenchmarks }
-#ifdef useCompilerInfo
-      buildCompilerId = unknownCompilerInfo (CompilerId buildCompilerFlavor compilerVersion) NoAbiTag
-#else
-      buildCompilerId = CompilerId buildCompilerFlavor compilerVersion
-#endif
   case finalizePackageDescription [] (const True) buildPlatform buildCompilerId [] genericDesc' of
     Left e -> putStrLn $ "Issue with package configuration\n" ++ show e
     Right (pkgDesc, _) -> print (dumpPackageDescription pkgDesc cabalFile)
+
+#ifdef useCompilerId
+buildCompilerId :: CompilerId
+buildCompilerId =
+  CompilerId buildCompilerFlavor compilerVersion
+#else
+buildCompilerId :: CompilerInfo
+buildCompilerId =
+  unknownCompilerInfo (CompilerId buildCompilerFlavor compilerVersion) NoAbiTag
+#endif
 
 main :: IO ()
 main = do

--- a/get-cabal-configuration.hs
+++ b/get-cabal-configuration.hs
@@ -24,12 +24,12 @@ import Control.Arrow (second)
 import Data.List (nub, isPrefixOf)
 import Data.Maybe (listToMaybe)
 #ifdef useCompilerInfo
-import Distribution.Compiler (AbiTag(NoAbiTag),CompilerFlavor(GHC),CompilerId(CompilerId),CompilerInfo,buildCompilerId,buildCompilerFlavor,unknownCompilerInfo)
+import Distribution.Compiler (AbiTag(NoAbiTag),CompilerFlavor(GHC),CompilerId(CompilerId),CompilerInfo,buildCompilerFlavor,unknownCompilerInfo)
 import Distribution.Simple.Compiler                  (compilerInfo)
 import Distribution.Simple.Configure                 (configCompilerAuxEx)
 import Distribution.Simple.Setup                     (emptyConfigFlags)
 #else
-import Distribution.Compiler (CompilerFlavor(GHC),CompilerId(CompilerId),buildCompilerId,buildCompilerFlavor)
+import Distribution.Compiler (CompilerFlavor(GHC),CompilerId(CompilerId),buildCompilerFlavor)
 #endif
 import Distribution.Package (PackageName(..),PackageIdentifier(..),Dependency(..))
 import Distribution.PackageDescription (PackageDescription(..),allBuildInfo

--- a/get-cabal-configuration.hs
+++ b/get-cabal-configuration.hs
@@ -19,6 +19,7 @@
 {-# LANGUAGE TypeSynonymInstances #-}
 {-# LANGUAGE FlexibleInstances #-}
 
+import Control.Arrow (second)
 import Data.List (nub, isPrefixOf)
 import Data.Maybe (listToMaybe)
 import Distribution.Compiler (CompilerFlavor(GHC),buildCompilerId)
@@ -123,7 +124,7 @@ dumpCabalConfiguration cabalFile = do
   genericDesc <- readPackageDescription silent cabalFile
   -- This let block is eerily like one in Cabal.Distribution.Simple.Configure
   let enableTest t = t { testEnabled = True }
-      flaggedTests = map (\(n, t) -> (n, mapTreeData enableTest t))
+      flaggedTests = map (second (mapTreeData enableTest))
                      (condTestSuites genericDesc)
       enableBenchmark bm = bm { benchmarkEnabled = True }
       flaggedBenchmarks = map (\(n, bm) ->

--- a/get-cabal-configuration.hs
+++ b/get-cabal-configuration.hs
@@ -136,15 +136,14 @@ dumpCabalConfiguration cabalFile = do
       flaggedTests = map (second (mapTreeData enableTest))
                      (condTestSuites genericDesc)
       enableBenchmark bm = bm { benchmarkEnabled = True }
-      flaggedBenchmarks = map (\(n, bm) ->
-                                (n, mapTreeData enableBenchmark bm))
+      flaggedBenchmarks = map (second (mapTreeData enableBenchmark))
                           (condBenchmarks genericDesc)
       genericDesc' = genericDesc { condTestSuites = flaggedTests
                                  , condBenchmarks = flaggedBenchmarks }
 #ifdef useCompilerInfo
       buildCompilerId = unknownCompilerInfo (CompilerId buildCompilerFlavor compilerVersion) NoAbiTag
 #else
-      buildCompilerId = (CompilerId buildCompilerFlavor compilerVersion)
+      buildCompilerId = CompilerId buildCompilerFlavor compilerVersion
 #endif
   case finalizePackageDescription [] (const True) buildPlatform buildCompilerId [] genericDesc' of
     Left e -> putStrLn $ "Issue with package configuration\n" ++ show e

--- a/get-cabal-flags.hs
+++ b/get-cabal-flags.hs
@@ -1,8 +1,0 @@
-import Data.Version (Version (Version))
-import Distribution.Simple.Utils (cabalVersion)
-
-main :: IO ()
-main =
-  putStrLn $ if cabalVersion >= Version [1,22] []
-             then "(\"-DuseCompilerInfo\")"
-             else "()"

--- a/get-cabal-flags.hs
+++ b/get-cabal-flags.hs
@@ -1,0 +1,8 @@
+import Data.Version (Version (Version))
+import Distribution.Simple.Utils (cabalVersion)
+
+main :: IO ()
+main =
+  putStrLn $ if cabalVersion >= Version [1,22] []
+             then "(\"-DuseCompilerInfo\")"
+             else "()"

--- a/test/flycheck-haskell-test.el
+++ b/test/flycheck-haskell-test.el
@@ -190,9 +190,10 @@
 ;; We're running hlint from here because we depend on the flags that
 ;; flycheck-haskell can derive for us
 (ert-deftest flycheck-haskell-hlint ()
-  (let ((args (flycheck-haskell-get-configuration-args flycheck-haskell-test-cabal-file)))
+  (let ((args (-map (lambda (d) (concat "--cpp-define=" d)) (flycheck-haskell-get-cpp-defines flycheck-haskell-test-cabal-file))))
+    (setq args (append args (list "get-cabal-configuration.hs")))
     (with-temp-buffer
-      (let ((result (apply 'call-process "hlint" nil t nil "get-cabal-configuration.hs" args)))
+      (let ((result (apply 'call-process "hlint" nil t nil args)))
         (should (string= (buffer-string) "No suggestions\n"))
         (should (= result 0))))))
 

--- a/test/flycheck-haskell-test.el
+++ b/test/flycheck-haskell-test.el
@@ -187,6 +187,15 @@
       (flycheck-haskell-compare-sets flycheck-ghc-search-path computed-path)
       (should (local-variable-p 'flycheck-ghc-search-path)))))
 
+;; We're running hlint from here because we depend on the flags that
+;; flycheck-haskell can derive for us
+(ert-deftest flycheck-haskell-hlint ()
+  (let ((args (flycheck-haskell-get-configuration-args flycheck-haskell-test-cabal-file)))
+    (with-temp-buffer
+      (let ((result (apply 'call-process "hlint" nil t nil "get-cabal-configuration.hs" args)))
+        (should (string= (buffer-string) "No suggestions\n"))
+        (should (= result 0))))))
+
 (provide 'flycheck-haskell-test)
 
 ;;; flycheck-haskell-test.el ends here

--- a/test/flycheck-haskell-test.el
+++ b/test/flycheck-haskell-test.el
@@ -28,6 +28,7 @@
 (require 'flycheck-haskell)
 
 (require 'cl-lib)
+(require 'dash)
 (require 'ert)
 
 
@@ -53,6 +54,10 @@
   (declare (indent 0))
   `(unwind-protect (progn ,@body)
      (flycheck-haskell-clear-config-cache)))
+
+(defun flycheck-haskell-compare-sets (actual expected)
+  "Compare ACTUAL and EXPECTED ignoring ordering."
+  (should (equal '() (-difference actual expected))))
 
 
 ;;; Test cases
@@ -98,23 +103,23 @@
     (should (= (hash-table-count flycheck-haskell-config-cache) 0))))
 
 (ert-deftest flycheck-haskell-read-cabal-configuration/has-all-extensions ()
-  (should (equal (assq 'extensions (flycheck-haskell-read-test-config))
-                 '(extensions "OverloadedStrings"
-                              "YouDontKnowThisOne"
-                              "GeneralizedNewtypeDeriving"))))
+  (flycheck-haskell-compare-sets (assq 'extensions (flycheck-haskell-read-test-config))
+                                  '(extensions "OverloadedStrings"
+                                               "YouDontKnowThisOne"
+                                               "GeneralizedNewtypeDeriving")))
 
 (ert-deftest flycheck-haskell-read-cabal-configuration/has-all-languages ()
-  (should (equal (assq 'languages (flycheck-haskell-read-test-config))
-                 '(languages "Haskell98" "SpamLanguage" "Haskell2010"))))
+  (flycheck-haskell-compare-sets (assq 'languages (flycheck-haskell-read-test-config))
+                                  '(languages "Haskell98" "SpamLanguage" "Haskell2010")))
 
 (ert-deftest flycheck-haskell-read-cabal-configuration/source-dirs ()
   (let* ((builddirs '("lib/" "." "src/"))
          (expanddir (lambda (fn)
                       (file-name-as-directory
                        (expand-file-name fn flycheck-haskell-test-dir)))))
-    (should (equal
-             (assq 'source-directories (flycheck-haskell-read-test-config))
-             (cons 'source-directories (-map expanddir builddirs))))))
+    (flycheck-haskell-compare-sets
+     (assq 'source-directories (flycheck-haskell-read-test-config))
+     (cons 'source-directories (-map expanddir builddirs)))))
 
 (ert-deftest flycheck-haskell-read-cabal-configuration/build-dirs ()
   (let* ((distdir (expand-file-name "dist/" flycheck-haskell-test-dir))
@@ -122,9 +127,9 @@
          (builddirs '("build" "build/autogen"
                  "build/flycheck-haskell-unknown-stuff/flycheck-haskell-unknown-stuff-tmp"
                  "build/flycheck-haskell-test/flycheck-haskell-test-tmp")))
-    (should (equal
-             (assq 'build-directories (flycheck-haskell-read-test-config))
-             (cons 'build-directories (-map expanddir builddirs))))))
+    (flycheck-haskell-compare-sets
+     (assq 'build-directories (flycheck-haskell-read-test-config))
+     (cons 'build-directories (-map expanddir builddirs)))))
 
 (ert-deftest flycheck-haskell-get-configuration/no-cache-entry ()
   (let* ((cabal-file flycheck-haskell-test-cabal-file))
@@ -156,13 +161,14 @@
 (ert-deftest flycheck-haskell-process-configuration/language-extensions ()
   (with-temp-buffer                     ; To scope the variables
     (flycheck-haskell-process-configuration (flycheck-haskell-read-test-config))
-    (should (equal flycheck-ghc-language-extensions
-                   '("OverloadedStrings"
-                     "YouDontKnowThisOne"
-                     "GeneralizedNewtypeDeriving"
-                     "Haskell98"
-                     "SpamLanguage"
-                     "Haskell2010")))
+    (flycheck-haskell-compare-sets
+     flycheck-ghc-language-extensions
+     '("OverloadedStrings"
+       "YouDontKnowThisOne"
+       "GeneralizedNewtypeDeriving"
+       "Haskell98"
+       "SpamLanguage"
+       "Haskell2010"))
     (should (local-variable-p 'flycheck-ghc-language-extensions))))
 
 (ert-deftest flycheck-haskell-process-configuration/search-path ()
@@ -173,12 +179,12 @@
                       "build/flycheck-haskell-test/flycheck-haskell-test-tmp"))
          (sourcedir (lambda (fn) (file-name-as-directory
                                   (expand-file-name fn flycheck-haskell-test-dir))))
-         (sourcedirs '("lib/" "." "src/")))
+         (sourcedirs '("lib/" "." "src/"))
+         (computed-path (append (-map builddir builddirs)
+                                (-map sourcedir sourcedirs))))
     (with-temp-buffer
       (flycheck-haskell-process-configuration (flycheck-haskell-read-test-config))
-      (should (equal flycheck-ghc-search-path
-                     (append (-map builddir builddirs)
-                             (-map sourcedir sourcedirs))))
+      (flycheck-haskell-compare-sets flycheck-ghc-search-path computed-path)
       (should (local-variable-p 'flycheck-ghc-search-path)))))
 
 (provide 'flycheck-haskell-test)


### PR DESCRIPTION
I was developing a library that needed bytestring-builder---which is an
additional package for older versions of bytestring (like the one in ghc
7.6), but whose functionality is included with the one included in ghc
>= 7.8.  So I had a conditional in my .cabal file.

The recent changes to get-cabal-configuration.hs caused flycheck to
start throwing warnings like:

    Suspicious state from syntax checker haskell-ghc: Checker haskell-ghc returned non-zero exit code 1, but no errors from output: <command line>: cannot satisfy -package bytestring-builder
        (use -v for more information)

    Checker definition probably flawed.

I tracked this down to get-cabal-configuration not handling conditionals
properly, and thus trying to reference a package that wasn't going to be
installed.

This change borrows code from Cabal in order to properly handle
conditionals---most of which really isn't about handling conditionals,
it's about making sure that the test and benchmark suites are enabled so
their dependencies will be picked up as well.  And then we also have to
be sure to filter out any references to our own package.