### PR TITLE
Ignore sandbox configuration when not present

### DIFF
--- a/flycheck-haskell.el
+++ b/flycheck-haskell.el
@@ -254,10 +254,11 @@ buffer."
     (let-alist (flycheck-haskell-get-cabal-config)
       (setq-local flycheck-haskell-ghc-executable .with-compiler))
 
-    (let-alist (flycheck-haskell-get-sandbox-config)
-      (setq-local flycheck-ghc-package-databases
-                  (cons .package-db flycheck-ghc-package-databases))
-      (setq-local flycheck-ghc-no-user-package-database t))))
+    (-when-let* ((sandbox-config (flycheck-haskell-get-sandbox-config)))
+      (let-alist sandbox-config
+        (setq-local flycheck-ghc-package-databases
+                    (cons .package-db flycheck-ghc-package-databases))
+        (setq-local flycheck-ghc-no-user-package-database t)))))
 
 ;;;###autoload
 (defun flycheck-haskell-setup ()

--- a/test/test-helper.el
+++ b/test/test-helper.el
@@ -1,0 +1,9 @@
+(require 'f)
+
+(defvar flycheck-haskell-test-path
+  (f-dirname (f-this-file)))
+
+(defvar flycheck-haskell-code-path
+  (f-parent flycheck-haskell-test-path))
+
+(require 'flycheck-haskell (f-expand "flycheck-haskell.el" flycheck-haskell-code-path))


### PR DESCRIPTION
I don't use cabal sandboxes for haskell development, so when I updated I
started getting the error:

  Error while checking syntax automatically: (error "Value (nil) of flycheck-ghc-package-databases for option \"-package-db\" is not a list of strings") [10 times]

This was because the prior code would create a single-entry list
of (nil).  This change simply skips monkeying with the sandbox config
stuff entirely if there isn't one, which seems like the correct course
of action.