### PR TITLE
Fix ‘flycheck-haskell-read-cabal-configuration’

### DIFF
--- a/flycheck-haskell.el
+++ b/flycheck-haskell.el
@@ -121,7 +121,7 @@ Take the base command from `flycheck-haskell-runghc-command'."
          (command (flycheck-haskell-runghc-command args)))
     (with-temp-buffer
       (let ((result (apply 'call-process (car command)
-                           nil t nil (cdr args))))
+                           nil t nil (cdr command))))
         (when (= result 0)
           (goto-char (point-min))
           (read (current-buffer)))))))


### PR DESCRIPTION
This eliminates the problem described in #42. I don't see how this was *problem on my side*. This is obviously a bug that should affect everyone (at least that's my current understanding). Did you try to use `flycheck-haskell` yourself recently, when I reported the issue?

With all due respect, I cannot understand why this bug manifested itself for me but was invisible for you.