### PR TITLE
Limit visible packages to actual dependencies

### DIFF
--- a/flycheck-haskell.el
+++ b/flycheck-haskell.el
@@ -257,7 +257,11 @@ buffer."
                 (append .extensions .languages
                         flycheck-ghc-language-extensions))
     (setq-local flycheck-ghc-args
-                (append .other-options flycheck-ghc-args))))
+                (append .other-options
+                        (cons "-hide-all-packages"
+                              (mapcar (apply-partially #'concat "-package ")
+                                      .dependencies))
+                        flycheck-ghc-args))))
 
 (defun flycheck-haskell-configure ()
   "Set paths and package database for the current project."


### PR DESCRIPTION
See #47, this solves the problem of “Ambiguous module name ‘Crypto.Hash’: it was found in multiple packages”.

Edit: Connects to #47 