### PR TITLE
Native support for autogenerated cabal CPP macros

### DIFF
--- a/flycheck-haskell.el
+++ b/flycheck-haskell.el
@@ -252,6 +252,9 @@ buffer."
                         flycheck-ghc-language-extensions))
     (setq-local flycheck-ghc-args
                 (append .other-options
+                        (seq-map (apply-partially #'concat "-I")
+                                 .autogen-directories)
+                        '("-optP-include" "-optPcabal_macros.h")
                         (cons "-hide-all-packages"
                               (seq-mapcat (apply-partially #'list "-package")
                                           .dependencies))

--- a/flycheck-haskell.el
+++ b/flycheck-haskell.el
@@ -258,7 +258,11 @@ buffer."
                         (cons "-hide-all-packages"
                               (seq-mapcat (apply-partially #'list "-package")
                                           .dependencies))
-                        flycheck-ghc-args))))
+                        flycheck-ghc-args))
+    (setq-local flycheck-hlint-args
+                (append (seq-mapcat (apply-partially #'list "--cpp-include")
+                                    .autogen-directories)
+                        '("--cpp-file" "cabal_macros.h")))))
 
 (defun flycheck-haskell-configure ()
   "Set paths and package database for the current project."


### PR DESCRIPTION
This provides support for automatic configuration of cabal macros for `haskell-ghc`, `haskell-stack-ghc` and `haskell-hlint` without extra configuration required from the user.

AFAIK, adding the cabal macros arguments to the GHC checkers is harmless even if the `cabal_macro.h` file is not present. `hlint` errors when the `cabal_macros.h` file is not present, but considering that the `hlint` arguments will only be set when within a cabal project and that both `stack build` and `cabal build` always create the `cabal_macros.h`, I think it's a too far edge-case to make it worth bothering about but I'm open to improve it if you think otherwise.

The current cask tests pass but I'm not sure about how to add meaningful tests for this feature. If you need tests, I'd appreciate a hint about what I should look for.

I manually checked with spacemacs that it works with `stack` and `cabal-install` separately and both at the same time. I'm new to the world of emacs and elisp so watch out for noob mistakes :smirk:.

See flycheck/flycheck#713 and #39