### PR TITLE
Instruct stack to not override GHC_PACKAGE_PATH

### DIFF
--- a/flycheck-haskell.el
+++ b/flycheck-haskell.el
@@ -69,7 +69,7 @@
 
 (defcustom flycheck-haskell-runghc-command
   (if (executable-find "stack")
-      '("stack" "--verbosity" "silent" "runghc" "--")
+      '("stack" "--verbosity" "silent" "runghc" "--no-ghc-package-path" "--")
     '("runghc"))
   "Command for `runghc'.
 


### PR DESCRIPTION
Setting `GHC_PACKAGE_PATH` may cause wrong Cabal package to be picked up by `get-cabal-configuration` and may lead to build problems.

For instance, packages using c2hs have some autogenerated files. Build command must include directory to autogenerated files, which for stack looks like `.stack-work/dist/x86_64-linux/Cabal-1.22.8.0/build/autogen`. However, the ghc 7.10.3 compiler uses Cabal-1.22.5.0, therefore the
correct autogen directory is actually `.stack-work/dist/x86_64-linux/Cabal-1.22.5.0/build/autogen`.

This should fix #57 bug.