### PR TITLE
Update for ghc 8.2

### DIFF
--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -1,0 +1,2 @@
+
+- ignore: {name: "Use fewer imports"}

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,9 @@ env:
     # GHC 7.10
     - EMACS_VERSION=24.3 STACK_YAML=stack-7.10.yaml
     - EMACS_VERSION=24.5 STACK_YAML=stack-7.10.yaml
+    # GHC 8.0
+    - EMACS_VERSION=24.3 STACK_YAML=stack-8.0.yaml
+    - EMACS_VERSION=24.5 STACK_YAML=stack-8.0.yaml
 before_install:
   - export PATH="$HOME/bin:$HOME/.local/bin::$PATH"
   - export STACK_YAML="${TRAVIS_BUILD_DIR}/${STACK_YAML}"

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,8 @@
 master (in development)
 =======================
 
+- Support GHC 8.2 with Cabal 2.0 [GH-66]
+
 0.8 (May 24, 2016)
 ==================
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,11 @@ following to your `init.el`:
   '(add-hook 'flycheck-mode-hook #'flycheck-haskell-setup))
 ```
 
+Supported GHC versions
+----------------------
+
+Tested with GHC `7.8.4`, `7.10.3`, `8.0.1`, `8.0.2`, `8.2.1-rc2`.
+
 Usage
 -----
 

--- a/get-cabal-configuration.hs
+++ b/get-cabal-configuration.hs
@@ -34,6 +34,7 @@ module Main (main) where
 #define Cabal2 0
 #endif
 
+import qualified Control.Applicative
 import Data.List (nub, isPrefixOf)
 import Data.Maybe (listToMaybe)
 #ifdef USE_COMPILER_ID
@@ -235,7 +236,7 @@ getConcretePackageDescription genericDesc = do
             { testsRequested      = True
             , benchmarksRequested = True
             }
-    fst <$> finalizePD
+    fst Control.Applicative.<$> finalizePD
         []           -- Flag assignment
         enabled      -- Enable all components
         (const True) -- Whether given dependency is available
@@ -260,7 +261,7 @@ getConcretePackageDescription genericDesc = do
             { condTestSuites = flaggedTests
             , condBenchmarks = flaggedBenchmarks
             }
-    fmap fst $ finalizePackageDescription
+    fst Control.Applicative.<$> finalizePackageDescription
         []
         (const True)
         buildPlatform

--- a/stack-8.0.yaml
+++ b/stack-8.0.yaml
@@ -1,0 +1,2 @@
+resolver: lts-8.14
+require-stack-version: '>= 0.1.8.0'


### PR DESCRIPTION
Fix for #66 and update for ghc 8.2. I tested with `ghc-8.2.1-rc2` available at the moment, but hopefully it would work with the release as well.

I also tested that files compile on linux with ghcs `7.8.4`, `7.10.3`, `8.0.1` and `8.0.2`.