### PR TITLE
Get GHC options from cpp-options cabal fields in addition to other sources

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@ master (in development)
 =======================
 
 - Support GHC 8.2 with Cabal 2.0 [GH-66]
+- Use `cpp-options` cabal file field to get more options for GHC [GH-68]
 
 0.8 (May 24, 2016)
 ==================

--- a/test/flycheck-haskell-test.cabal
+++ b/test/flycheck-haskell-test.cabal
@@ -10,6 +10,7 @@ library
   extensions:          OverloadedStrings
   build-depends:       base >=4.7 && <4.8
   default-language:    Haskell98
+  cpp-options:         -DDEBUG=1
 
 executable flycheck-haskell-test
   hs-source-dirs:      src/
@@ -17,6 +18,7 @@ executable flycheck-haskell-test
   build-depends:       base >=4.7 && <4.8,
                        bytestring
   default-language:    Haskell2010
+  ghc-options:         -Wall
 
 executable flycheck-haskell-unknown-stuff
   -- This shall test the handling of unknown language and extension values

--- a/test/flycheck-haskell-test.el
+++ b/test/flycheck-haskell-test.el
@@ -108,6 +108,14 @@
           (should (seq-find (apply-partially #'string-match-p cabal-re)
                             .build-directories)))))))
 
+(ert-deftest flycheck-haskell-read-cabal-configuration/cpp-options ()
+  (let-alist (flycheck-haskell-read-test-config)
+    (should (member "-DDEBUG=1" .other-options))))
+
+(ert-deftest flycheck-haskell-read-cabal-configuration/ghc-options ()
+  (let-alist (flycheck-haskell-read-test-config)
+    (should (member "-Wall" .other-options))))
+
 (ert-deftest flycheck-haskell-get-configuration/no-cache-entry ()
   (let* ((cabal-file flycheck-haskell-test-cabal-file))
     (cl-letf (((symbol-function 'flycheck-haskell-read-cabal-configuration)


### PR DESCRIPTION
Fix for #68. @flycheck/haskell Please review