### PR TITLE
Use flycheck-executable-find to search executables

### DIFF
--- a/flycheck-haskell.el
+++ b/flycheck-haskell.el
@@ -73,9 +73,9 @@
   :link '(url-link :tag "Github" "https://github.com/flycheck/flycheck-haskell"))
 
 (defcustom flycheck-haskell-runghc-command
-  (if (executable-find "stack")
+  (if (funcall flycheck-executable-find "stack")
       '("stack" "--verbosity" "silent" "runghc" "--no-ghc-package-path" "--" "--ghc-arg=-i")
-    '("runghc" "-i"))
+    `(,(funcall flycheck-executable-find "runghc") "-i"))
   "Command for `runghc'.
 
 This library uses `runghc' to run various Haskell helper scripts


### PR DESCRIPTION
> Flycheck uses the function given by the option flycheck-executable-find to search for executables, and passes all syntax checker commands through flycheck-command-wrapper-function before running them. These features let you adapt Flycheck to search executables and run commands in sandboxed environments such as bundle exec or nix-shell.

[ref](http://www.flycheck.org/en/27/_downloads/flycheck.html)

flycheck-haskell should do the same.

With this change, I can successfully use flycheck-haskell in a Nix-based (and cabal new-style build) Haskell project. cf. https://github.com/reflex-frp/reflex-platform/pull/235