### PR TITLE
Initial support for cabal nix-style builds

### DIFF
--- a/flycheck-haskell.el
+++ b/flycheck-haskell.el
@@ -80,7 +80,13 @@
       (stack-exe
        `(,stack-exe "--verbosity" "silent" "runghc" "--no-ghc-package-path" "--" "--ghc-arg=-i"))
       (runghc-exe
-       `(,runghc-exe "-i"))
+       ;; Dependencies needed by get-cabal-configuration.hs
+       `(,runghc-exe "--ghc-arg=-i"
+                     "--ghc-arg=-packageCabal"
+                     "--ghc-arg=-packagebytestring"
+                     "--ghc-arg=-packageprocess"
+                     "--ghc-arg=-packagedirectory"
+                     "--ghc-arg=-packagefilepath"))
       (t
        ;; A reasonable default.
        '("runghc" "-i"))))

--- a/flycheck-haskell.el
+++ b/flycheck-haskell.el
@@ -81,12 +81,15 @@
        `(,stack-exe "--verbosity" "silent" "runghc" "--no-ghc-package-path" "--" "--ghc-arg=-i"))
       (runghc-exe
        ;; Dependencies needed by get-cabal-configuration.hs
-       `(,runghc-exe "--ghc-arg=-i"
-                     "--ghc-arg=-packageCabal"
-                     "--ghc-arg=-packagebytestring"
-                     "--ghc-arg=-packageprocess"
-                     "--ghc-arg=-packagedirectory"
-                     "--ghc-arg=-packagefilepath"))
+       `(,runghc-exe "--"
+                     "-i"
+                     "-packageCabal"
+                     "-packagebase"
+                     "-packagebytestring"
+                     "-packagecontainers"
+                     "-packageprocess"
+                     "-packagedirectory"
+                     "-packagefilepath"))
       (t
        ;; A reasonable default.
        '("runghc" "-i"))))
@@ -143,7 +146,10 @@ Take the base command from `flycheck-haskell-runghc-command'."
 
 (defun flycheck-haskell--read-configuration-with-helper (command)
   (with-temp-buffer
-    (pcase (apply 'call-process (car command) nil t nil (cdr command))
+    ;; Discard stderr. When runghc loads a package environment it prints some
+    ;; info to the stderr. Apparently there is no GHC parameter to silence that
+    ;; message.
+    (pcase (apply 'call-process (car command) nil (list t nil) nil (cdr command))
       (0 (goto-char (point-min))
          (read (current-buffer)))
       (retcode (message "Reading Haskell configuration failed with exit code %s and output:\n%s"
@@ -313,9 +319,10 @@ buffer."
                                   .autogen-directories)
                          (when (car .should-include-version-header)
                            '("-optP-include" "-optPcabal_macros.h"))
-                         (cons "-hide-all-packages"
-                               (seq-map (apply-partially #'concat "-package=")
-                                        .dependencies))
+                         (when .dependencies
+                           (cons "-hide-all-packages"
+                                 (seq-map (apply-partially #'concat "-package=")
+                                          .dependencies)))
                          flycheck-ghc-args)))
     (setq-local flycheck-hlint-args
                 (flycheck-haskell--delete-dups

--- a/get-cabal-configuration.hs
+++ b/get-cabal-configuration.hs
@@ -85,8 +85,10 @@ import Distribution.Compiler
        (AbiTag(NoAbiTag), CompilerFlavor(GHC), CompilerId(CompilerId),
         CompilerInfo, buildCompilerFlavor, unknownCompilerInfo)
 #endif
-import Distribution.Package
-       (pkgName, Dependency(..))
+#if __GLASGOW_HASKELL__ < 800
+import Distribution.Package (pkgName)
+#endif
+import Distribution.Package (Dependency(..))
 import Distribution.PackageDescription
        (GenericPackageDescription,
         PackageDescription(..), allBuildInfo, BuildInfo(..),
@@ -117,7 +119,10 @@ import Distribution.PackageDescription (allBuildDepends)
 
 #if defined(Cabal20) || defined(Cabal22) || defined(Cabal24)
 import Control.Monad (filterM)
-import Distribution.Package (unPackageName, depPkgName, PackageName)
+import Distribution.Package (unPackageName, depPkgName)
+#if __GLASGOW_HASKELL__ < 800
+import Distribution.Package (PackageName)
+#endif
 import Distribution.PackageDescription.Configuration (finalizePD)
 import Distribution.Types.ComponentRequestedSpec (ComponentRequestedSpec(..))
 import Distribution.Types.ForeignLib (ForeignLib(foreignLibName))
@@ -330,7 +335,11 @@ dumpPackageDescription pkgDesc projectDir = do
             , cons (sym "source-directories") sourceDirs
             , cons (sym "extensions") exts
             , cons (sym "languages") langs
+#if __GLASGOW_HASKELL__ < 800
+            -- No need to specify dependencies with package environments.
+            -- https://downloads.haskell.org/~ghc/8.0.2/docs/html/users_guide/packages.html#package-environments
             , cons (sym "dependencies") deps
+#endif
             , cons (sym "other-options") (cppOpts ++ ghcOpts)
             , cons (sym "autogen-directories") (map normalise autogenDirs)
             , cons (sym "should-include-version-header") [not ghcIncludesVersionMacro]
@@ -348,12 +357,15 @@ dumpPackageDescription pkgDesc projectDir = do
     langs :: [Language]
     langs = nub (concatMap allLanguages buildInfo)
 
+#if __GLASGOW_HASKELL__ < 800
+
     thisPackage :: PackageName
     thisPackage = pkgName (package pkgDesc)
 
     deps :: [Dependency]
     deps =
         nub (filter (\(Dependency name _) -> name /= thisPackage) (buildDepends' pkgDesc))
+#endif
 
     -- The "cpp-options" configuration field.
     cppOpts :: [String]
@@ -401,12 +413,14 @@ readHPackPkgDescr exe configFile projectDir = do
         , Process.cwd     = Just projectDir
         }
 
+#if __GLASGOW_HASKELL__ < 800
 buildDepends' :: PackageDescription -> [Dependency]
 buildDepends' =
 #if defined(Cabal24)
     allBuildDepends
 #else
     buildDepends
+#endif
 #endif
 
 readGenericPkgDescr :: FilePath -> IO GenericPackageDescription


### PR DESCRIPTION
This does the the job for MacOS machine but I haven't tested it in other platforms with older Cabal or GHC releases.

There is, however, a Lisp error when flycheck-haskell is loaded. My ELisp fu is not enough to track down what's going so I'm pasting the backtrace below, so I'd appreciate any ELisp tip.

Also, if I'm not mistaken there is a different `dist` directory layout when there are separate builds per component (there are single character directories for each component), but I don't think that's the default build option, at least nor for me. I may look into that in another PR.


```
Debugger entered--Lisp error: (wrong-type-argument listp Loaded)
  assq(build-directories Loaded)
  (cdr (assq 'build-directories alist))
  (let ((\.build-directories (cdr (assq 'build-directories alist))) (\.source-directories (cdr (assq 'source-directories alist))) (\.extensions (cdr (assq 'extensions alist))) (\.languages (cdr (assq 'languages alist))) (\.other-options (cdr (assq 'other-options alist))) (\.autogen-directories (cdr (assq 'autogen-directories alist))) (\.should-include-version-header (cdr (assq 'should-include-version-header alist))) (\.dependencies (cdr (assq 'dependencies alist)))) (set (make-local-variable 'flycheck-ghc-search-path) (flycheck-haskell--delete-dups (append \.build-directories \.source-directories flycheck-ghc-search-path))) (set (make-local-variable 'flycheck-ghc-language-extensions) (flycheck-haskell--delete-dups (append \.extensions \.languages flycheck-ghc-language-extensions))) (set (make-local-variable 'flycheck-ghc-args) (flycheck-haskell--delete-dups (append \.other-options (seq-map (apply-partially (function concat) "-I") \.autogen-directories) (if (car \.should-include-version-header) (progn '("-optP-include" "-optPcabal_macros.h"))) (cons "-hide-all-packages" (seq-map (apply-partially (function concat) "-package=") \.dependencies)) flycheck-ghc-args))) (set (make-local-variable 'flycheck-hlint-args) (flycheck-haskell--delete-dups (append (seq-map (apply-partially (function concat) "--cpp-include=") \.autogen-directories) '("--cpp-file=cabal_macros.h")))))
  (let ((alist config)) (let ((\.build-directories (cdr (assq 'build-directories alist))) (\.source-directories (cdr (assq 'source-directories alist))) (\.extensions (cdr (assq 'extensions alist))) (\.languages (cdr (assq 'languages alist))) (\.other-options (cdr (assq 'other-options alist))) (\.autogen-directories (cdr (assq 'autogen-directories alist))) (\.should-include-version-header (cdr (assq 'should-include-version-header alist))) (\.dependencies (cdr (assq 'dependencies alist)))) (set (make-local-variable 'flycheck-ghc-search-path) (flycheck-haskell--delete-dups (append \.build-directories \.source-directories flycheck-ghc-search-path))) (set (make-local-variable 'flycheck-ghc-language-extensions) (flycheck-haskell--delete-dups (append \.extensions \.languages flycheck-ghc-language-extensions))) (set (make-local-variable 'flycheck-ghc-args) (flycheck-haskell--delete-dups (append \.other-options (seq-map (apply-partially (function concat) "-I") \.autogen-directories) (if (car \.should-include-version-header) (progn '("-optP-include" "-optPcabal_macros.h"))) (cons "-hide-all-packages" (seq-map (apply-partially (function concat) "-package=") \.dependencies)) flycheck-ghc-args))) (set (make-local-variable 'flycheck-hlint-args) (flycheck-haskell--delete-dups (append (seq-map (apply-partially (function concat) "--cpp-include=") \.autogen-directories) '("--cpp-file=cabal_macros.h"))))))
  flycheck-haskell-process-configuration(Loaded)
  (progn (flycheck-haskell-process-configuration config))
  (if config (progn (flycheck-haskell-process-configuration config)))
  (let ((config (flycheck-haskell-get-configuration config-file))) (if config (progn (flycheck-haskell-process-configuration config))))
  (progn (let ((config (flycheck-haskell-get-configuration config-file))) (if config (progn (flycheck-haskell-process-configuration config)))))
  (if config-file (progn (let ((config (flycheck-haskell-get-configuration config-file))) (if config (progn (flycheck-haskell-process-configuration config))))))
  (let ((config-file (flycheck-haskell--find-config-file))) (if config-file (progn (let ((config (flycheck-haskell-get-configuration config-file))) (if config (progn (flycheck-haskell-process-configuration config)))))))
  (progn (let ((config-file (flycheck-haskell--find-config-file))) (if config-file (progn (let ((config (flycheck-haskell-get-configuration config-file))) (if config (progn (flycheck-haskell-process-configuration config))))))) (let ((alist (flycheck-haskell-get-cabal-config))) (let ((\.with-compiler (cdr (assq 'with-compiler alist)))) (if \.with-compiler (progn (set (make-local-variable 'flycheck-haskell-ghc-executable) \.with-compiler))))) (let ((alist (flycheck-haskell-get-sandbox-config))) (let ((\.package-db (cdr (assq 'package-db alist)))) (if \.package-db (progn (set (make-local-variable 'flycheck-ghc-package-databases) (flycheck-haskell--delete-dups (cons \.package-db flycheck-ghc-package-databases))) (set (make-local-variable 'flycheck-ghc-no-user-package-database) t))))))
  (if (and (buffer-file-name) (file-directory-p default-directory)) (progn (let ((config-file (flycheck-haskell--find-config-file))) (if config-file (progn (let ((config (flycheck-haskell-get-configuration config-file))) (if config (progn (flycheck-haskell-process-configuration config))))))) (let ((alist (flycheck-haskell-get-cabal-config))) (let ((\.with-compiler (cdr (assq 'with-compiler alist)))) (if \.with-compiler (progn (set (make-local-variable 'flycheck-haskell-ghc-executable) \.with-compiler))))) (let ((alist (flycheck-haskell-get-sandbox-config))) (let ((\.package-db (cdr (assq 'package-db alist)))) (if \.package-db (progn (set (make-local-variable 'flycheck-ghc-package-databases) (flycheck-haskell--delete-dups (cons \.package-db flycheck-ghc-package-databases))) (set (make-local-variable 'flycheck-ghc-no-user-package-database) t)))))))
  flycheck-haskell-configure()
  run-hooks(flycheck-mode-hook flycheck-mode-on-hook)
  flycheck-mode()
  flycheck-mode-on-safe()
  global-flycheck-mode(1)
  (progn (global-flycheck-mode 1))
  (if syntax-checking-enable-by-default (progn (global-flycheck-mode 1)))
  (lambda nil (if syntax-checking-enable-by-default (progn (global-flycheck-mode 1))))()
  funcall((lambda nil (if syntax-checking-enable-by-default (progn (global-flycheck-mode 1)))))
  lazy-load-flycheck()
  spacemacs//transient-hook-lazy-load-flycheck()
  run-hooks(change-major-mode-after-body-hook prog-mode-hook haskell-mode-hook)
  apply(run-hooks (change-major-mode-after-body-hook prog-mode-hook haskell-mode-hook))
  run-mode-hooks(haskell-mode-hook)
  haskell-mode()
```

See #65.

Remaining tasks:

- [ ] Report runghc stderr in case of failure.
- [ ] Support both old (including stack) and new build styles (with or without package environments).
- [x] Fix test errors.
- [ ] Fix test failures/Update tests.