### PR TITLE
Ignore -Wmissing-home-modules option

### DIFF
--- a/get-cabal-configuration.hs
+++ b/get-cabal-configuration.hs
@@ -336,9 +336,15 @@ allowedOptionPrefixes =
     , "-opt"
     ]
 
+forbiddenOptions :: Set String
+forbiddenOptions = S.fromList
+   [ "-Wmissing-home-modules"
+   , "-Werror=missing-home-modules"
+   ]
+
 isAllowedOption :: String -> Bool
 isAllowedOption opt =
-    S.member opt allowedOptions || any (`isPrefixOf` opt) allowedOptionPrefixes
+    S.member opt allowedOptions || any (`isPrefixOf` opt) allowedOptionPrefixes && S.notMember opt forbiddenOptions
 
 dumpPackageDescription :: PackageDescription -> FilePath -> IO Sexp
 dumpPackageDescription pkgDesc projectDir = do


### PR DESCRIPTION
Flycheck was failing for a project where this option enabled.

If we wanted to be compliant with this warning, we would have find all the files corresponding to the imported modules of the file being checked, which I think it could be too much of a hassle.

See its [`-Wmissing-home-modules`documentation](https://downloads.haskell.org/~ghc/latest/docs/html/users_guide/using-warnings.html#ghc-flag--Wmissing-home-modules).