### PR TITLE
fix import

### DIFF
--- a/get-cabal-configuration.hs
+++ b/get-cabal-configuration.hs
@@ -197,7 +197,9 @@ import Distribution.Pretty (prettyShow)
 #if defined(Cabal300rLater)
 import Distribution.PackageDescription (mkFlagAssignment)
 #else
+# if defined(Cabal2020rLater)
 import Distribution.Types.GenericPackageDescription (mkFlagAssignment)
+# endif
 #endif
 
 #if defined(Cabal22OrLater)

--- a/get-cabal-configuration.hs
+++ b/get-cabal-configuration.hs
@@ -191,7 +191,7 @@ import Distribution.PackageDescription
 
 #if defined(Cabal22OrLater)
 import Distribution.Pretty (prettyShow)
-import Distribution.Types.GenericPackageDescription (mkFlagAssignment)
+import Distribution.PackageDescription (mkFlagAssignment)
 #endif
 
 #if defined(Cabal22OrLater)

--- a/get-cabal-configuration.hs
+++ b/get-cabal-configuration.hs
@@ -36,6 +36,7 @@ module Main (main) where
 #if defined(GHC_INCLUDES_VERSION_MACRO)
 # if MIN_VERSION_Cabal(3, 0, 0)
 #  define Cabal30 1
+#  define Cabal300rLater 1
 #  define Cabal22OrLater 1
 #  define Cabal20OrLater 1
 # elif MIN_VERSION_Cabal(2, 3, 0)
@@ -191,7 +192,12 @@ import Distribution.PackageDescription
 
 #if defined(Cabal22OrLater)
 import Distribution.Pretty (prettyShow)
+#endif
+
+#if defined(Cabal300rLater)
 import Distribution.PackageDescription (mkFlagAssignment)
+#else
+import Distribution.Types.GenericPackageDescription (mkFlagAssignment)
 #endif
 
 #if defined(Cabal22OrLater)


### PR DESCRIPTION
This pull request should fix the mkFlagAssignment import for cabal 3.x. See issue #106 

I did not test the code.