### PR TITLE
Fix warning for deprecated ByteString Builder import

### DIFF
--- a/get-cabal-configuration.hs
+++ b/get-cabal-configuration.hs
@@ -82,7 +82,9 @@ module Main (main) where
 #endif
 
 import qualified Data.ByteString.Char8 as C8
-#if __GLASGOW_HASKELL__ > 704
+#if __GLASGOW_HASKELL__ > 810
+import qualified Data.ByteString.Builder as CL8.Builder
+#elif __GLASGOW_HASKELL__ > 704
 import qualified Data.ByteString.Lazy.Builder as CL8.Builder
 #else
 import qualified Data.ByteString.Lazy.Char8 as CL8


### PR DESCRIPTION
Use new import with recent GHC versions to avoid:

  get-cabal-configuration.hs:86:1: warning: [-Wdeprecations]
      Module ‘Data.ByteString.Lazy.Builder’ is deprecated:
      Use Data.ByteString.Builder instead
  |
  86 | import qualified Data.ByteString.Lazy.Builder as CL8.Builder
  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^