### PR TITLE
Remove not needed Cabal-syntax package

### DIFF
--- a/flycheck-haskell.el
+++ b/flycheck-haskell.el
@@ -80,7 +80,6 @@
       (stack-exe
        `(,stack-exe "--verbosity" "silent" "runghc" "--no-ghc-package-path" "--" "-i"
                     "-packageCabal"
-                    "-packageCabal-syntax"
                     "-packagebase"
                     "-packagebytestring"
                     "-packagecontainers"
@@ -90,7 +89,6 @@
       (runghc-exe
        `(,runghc-exe "--" "-i"
                      "-packageCabal"
-                     "-packageCabal-syntax"
                      "-packagebase"
                      "-packagebytestring"
                      "-packagecontainers"


### PR DESCRIPTION
Seems like Cabal-syntax is re-exported from Cabal itself and this is causing tons of these errors:

```
  Reading Haskell configuration failed with exit code 1 and output:

  /home/ricardo/.emacs.d/elpa/flycheck-haskell-20230706.1439/get-cabal-configuration.hs:118:1: error:
      Ambiguous module name ‘Distribution.ModuleName’:
        it was found in multiple packages:
        Cabal-3.6.3.0 Cabal-syntax-3.8.1.0
      |
  118 | import Distribution.ModuleName (ModuleName)
      | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

  /home/ricardo/.emacs.d/elpa/flycheck-haskell-20230706.1439/get-cabal-configuration.hs:119:1: error:
      Ambiguous module name ‘Distribution.ModuleName’:
        it was found in multiple packages:
        Cabal-3.6.3.0 Cabal-syntax-3.8.1.0
      |
  119 | import qualified Distribution.ModuleName as ModuleName
      | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

  /home/ricardo/.emacs.d/elpa/flycheck-haskell-20230706.1439/get-cabal-configuration.hs:120:1: error:
      Ambiguous module name ‘Distribution.PackageDescription’:
        it was found in multiple packages:
        Cabal-3.6.3.0 Cabal-syntax-3.8.1.0
      |
  120 | import Distribution.PackageDescription ()
      | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```

Seems like this was added on: https://github.com/flycheck/flycheck-haskell/pull/118/commits/e2e810d8f042f915eecea1e8669dc38153d4588c#diff-afbba6f6e023f74356e1dc0d0cf82a0d652ed2d644ac255c71937de6af72a2d8

I can see the same package exported by both, hence I think we should remove `Cabal-syntax` which solves the problem for me:
- https://hackage.haskell.org/package/Cabal-3.6.3.0/docs/Distribution-ModuleName.html
- https://hackage.haskell.org/package/Cabal-syntax-3.10.1.0/docs/Distribution-ModuleName.html

I'm using ghc 9.2.5, cabal 3.6.2.0.